### PR TITLE
Docupの設定にBase pathを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
     <!-- Start app -->
     <script>
       docup.init({
-        title: "howtheytest-jp"
+        title: "howtheytest-jp",
+        base: '/howtheytest-jp',
       })
     </script>
   </body>


### PR DESCRIPTION
サイト https://tadashi0713.github.io/howtheytest-jp/ で左上のサイトタイトル部分を押すと、リンク先が https://tadashi0713.github.io/ になっていました。

<img width="896" alt="スクリーンショット 2021-09-26 20 46 36" src="https://user-images.githubusercontent.com/7846521/134806430-09b45aaf-a652-4929-af6d-95967e4bead5.png">

飛んだ先にページが無いので404になってしまいます😇 

本来は、https://tadashi0713.github.io/howtheytest-jp/ に飛んでほしいはずなので、Docupの設定でbaseを設定しています。

https://docup.egoist.sh/#base

上記のDocupの設定ページにも

> The base path your website is located at. If you are serving your docs under a sub path like https://user.github.io/awesome-project, you need to set this option to /awesome-project.

と書いてあるので、 おそらく問題ないかと思います。

手元で細かくページ遷移などを確認していないので、うまく動いていなかったら無視していただいて構わないです。🙏 